### PR TITLE
Corrected spelling mismatch

### DIFF
--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -18,7 +18,7 @@ func TestBitmapSort(t *testing.T) {
 	expected := [5]uint64{1,3,4,6,7}
 	actual := [5]uint64{}
 
-	for _, offset := range origal {
+	for _, offset := range original {
 		bmap.SetBit(offset, 1)
 	}
 


### PR DESCRIPTION
Fix in line 17 caused a mismatch at line 21